### PR TITLE
Add links to next steps topic

### DIFF
--- a/docs/getting-started/next-steps.md
+++ b/docs/getting-started/next-steps.md
@@ -3,19 +3,39 @@ hide_next: true
 ---
 # Next Steps
 
-[![Slack Link](../images/slack-button.svg)](https://slack.knative.dev/){target=_blank}
+This topic provides a list of resources to help you continue your Knative journey.
 
-## :test_tube: Try out a Knative Sample
-Converting a Kubernetes Service to a Knative Service
+[![Knative Slack Link](../images/slack-button.svg)](https://slack.knative.dev/){target=_blank}
 
-## :page_with_curl: Explore the Knative Docs
+## :test_tube: Knative samples
 
+Try out some of the Knative samples below:
 
-## :book: Knative Books
+- [Converting a Kubernetes Service to a Knative Service](../serving/convert-deployment-to-knative-service/)
+- [Knative Serving code samples](../serving/samples/)
+- [Knative Eventing and Event source code samples](../eventing/samples/)
 
+## :page_with_curl: Explore the Knative docs
 
-## :globe_with_meridians: Other Knative Links
+Explore the guides below for documentation specific to your role:
 
+- [Developer Guide](../developer/README.md)
+- [Admin Guide](../admin/README.md)
+
+## :book: Knative books
+
+Books to help you understand Knative concepts and get additional examples:
+
+- [Knative in Action](https://www.manning.com/books/knative-in-action)
+- [Knative Cookbook](https://www.oreilly.com/library/view/knative-cookbook/9781492061182/)
+
+## :globe_with_meridians: Other Knative links
+
+Other links to help you get started with Knative:
+
+- [Knative YouTube Channel](https://www.youtube.com/channel/UCq7cipu-A1UHOkZ9fls1N8A)
+- [Knative.tips](https://knative.tips/)
 
 ## :question: Are we missing something?
-We'd love to help you along the next step of your Knative journey, if we're missing something on this page that you feel should be here [please let us know!](https://forms.gle/Ab44BUBowmnnJsdW9)
+
+We'd love to help you along the next step of your Knative journey. If we're missing something on this page that you feel should be here, please [give us feedback](https://forms.gle/Ab44BUBowmnnJsdW9)!


### PR DESCRIPTION
I've added my changes to the next steps page here. The following items from the list in https://github.com/knative/docs/issues/3857 have been added:

- Developer's Guide
- Admin's Guide
- Knative in Action
- Knative Cookbook
- Knative.tips
- Knative YouTube Channel
- A Google Form to ask folks what we're missing
- Links to samples
- Link to Slack

I didn't add the Link to StackOverflow because I was unsure which link would be best and whether you want a button similar to the Slack link.

Let me know if you want me to add anything else.
